### PR TITLE
Prevent instrumentation at methods without body.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 env:
   global:
-    - TRAVIS_TAG=0.9.1
+    - TRAVIS_TAG=0.9.2
 
 jobs:
   include:

--- a/Injector/src/test/java/com/kanakis/resilient/perses/FaultTest.java
+++ b/Injector/src/test/java/com/kanakis/resilient/perses/FaultTest.java
@@ -94,5 +94,4 @@ public class FaultTest {
         TargetClass c = new TargetClass();
         c.targetMethod();
     }
-
 }

--- a/Injector/src/test/java/com/kanakis/resilient/perses/GetInvokedMethodsTest.java
+++ b/Injector/src/test/java/com/kanakis/resilient/perses/GetInvokedMethodsTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
-
 public class GetInvokedMethodsTest {
     private static MBeanWrapper mBeanWrapper;
 
@@ -54,5 +53,27 @@ public class GetInvokedMethodsTest {
 
         MethodProperties expectedMethodProperties = new MethodProperties("com.kanakis.resilient.perses.testApp.TargetClass", "helper", "()Z");
         assertTrue(res.contains(expectedMethodProperties));
+    }
+
+    @Test
+    public void should_not_return_methods_of_interface() throws Throwable {
+        AttackProperties properties = new AttackProperties();
+        properties.setClassPath("com.kanakis.resilient.perses.testApp.TargetInterface");
+        properties.setMethodName("targetMethod");
+
+        List<MethodProperties> res = mBeanWrapper.getInvokedMethods(properties);
+
+        assertTrue(res.isEmpty());
+    }
+
+    @Test
+    public void should_not_return_method_without_body() throws Throwable {
+        AttackProperties properties = new AttackProperties();
+        properties.setClassPath("com.kanakis.resilient.perses.testApp.TargetAbstractClass");
+        properties.setMethodName("methodWithoutBody");
+
+        List<MethodProperties> res = mBeanWrapper.getInvokedMethods(properties);
+
+        assertTrue(res.isEmpty());
     }
 }

--- a/Injector/src/test/java/com/kanakis/resilient/perses/GetMethodsOfClass.java
+++ b/Injector/src/test/java/com/kanakis/resilient/perses/GetMethodsOfClass.java
@@ -2,7 +2,6 @@ package com.kanakis.resilient.perses;
 
 import com.kanakis.resilient.perses.agent.MethodProperties;
 import com.kanakis.resilient.perses.core.AgentLoader;
-import com.kanakis.resilient.perses.core.AttackProperties;
 import com.kanakis.resilient.perses.core.MBeanWrapper;
 import com.sun.tools.attach.VirtualMachine;
 import org.junit.AfterClass;
@@ -13,6 +12,7 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 
@@ -35,7 +35,21 @@ public class GetMethodsOfClass {
     public void should_get_methods_of_class() throws Throwable {
         List<MethodProperties> res = mBeanWrapper.getMethodsOfClass("com.kanakis.resilient.perses.testApp.TargetClass");
 
-        assertTrue(res.size() == 4);
+        assertEquals(4, res.size());
+    }
+
+    @Test
+    public void should_not_return_methods_of_interface() throws Throwable {
+        List<MethodProperties> res = mBeanWrapper.getMethodsOfClass("com.kanakis.resilient.perses.testApp.TargetInterface");
+
+        assertTrue(res.isEmpty());
+    }
+
+    @Test
+    public void should_not_return_method_without_body() throws Throwable {
+        List<MethodProperties> res = mBeanWrapper.getMethodsOfClass("com.kanakis.resilient.perses.testApp.TargetAbstractClass");
+
+        assertTrue(res.isEmpty());
     }
 
 }

--- a/Injector/src/test/java/com/kanakis/resilient/perses/testApp/TargetAbstractClass.java
+++ b/Injector/src/test/java/com/kanakis/resilient/perses/testApp/TargetAbstractClass.java
@@ -1,0 +1,6 @@
+package com.kanakis.resilient.perses.testApp;
+
+public abstract class TargetAbstractClass {
+
+    abstract boolean methodWithoutBody();
+}

--- a/Injector/src/test/java/com/kanakis/resilient/perses/testApp/TargetInterface.java
+++ b/Injector/src/test/java/com/kanakis/resilient/perses/testApp/TargetInterface.java
@@ -1,0 +1,6 @@
+package com.kanakis.resilient.perses.testApp;
+
+public interface TargetInterface {
+
+    boolean targetMethod();
+}

--- a/PersesUI/src/main/resources/static/js/searchBar.js
+++ b/PersesUI/src/main/resources/static/js/searchBar.js
@@ -21,7 +21,7 @@ const searchMethod = () => {
             signature: signature
         };
         getFromPerses(methodInfo)
-            .then(() => addChildrenToRoot(methodInfo))
+            .then(response => addChildrenToRoot(methodInfo, response.data))
             .catch(e => resultNotOk(e));
     }
 };

--- a/PersesUI/src/main/resources/static/js/treeview.js
+++ b/PersesUI/src/main/resources/static/js/treeview.js
@@ -1,4 +1,4 @@
-const addChildrenToRoot = (methodInfo) => {
+const addChildrenToRoot = (methodInfo, data) => {
 	const section = document.getElementById("calledMethodsSection");
 	section.classList.remove("hidden-lg");
 
@@ -34,6 +34,8 @@ const addChildrenToRoot = (methodInfo) => {
         }).then(res => addChildrenToNode(rootLi, res.data))
             .catch(error => alert("Could not find method " + error));
     });
+
+    addChildrenToNode(rootLi, data);
 };
 
 const addRoot = (className) => {


### PR DESCRIPTION
Perses will handle gracefully instrumention of methods without body, it will also not include such method when navigating invoked mehtods or methods of class.